### PR TITLE
Don't fail RSS feed imports when media descriptions are empty

### DIFF
--- a/src/DataSource/Rss.js
+++ b/src/DataSource/Rss.js
@@ -53,7 +53,7 @@ class Rss extends DataSource {
 			// Only supporting images for now
 			return !source["@_medium"] || source["@_medium"] === "image";
 		}).map(source => {
-			return `<img src="${source["@_url"]}" alt="${source["media:description"]["#text"]}">`;
+			return `<img src="${source["@_url"]}" alt="${source["media:description"]?.["#text"] || ""}">`;
 		}).join("\n");
 	}
 


### PR DESCRIPTION
If an image description is empty in an rss feed, the build fails with this message:
```
[11ty] Problem writing Eleventy templates:
[11ty] 1. Having trouble rendering 11ty.js template ./src/follow-feed.11ty.js (via TemplateContentRenderError)
[11ty] 2. Cannot read properties of undefined (reading '#text') (via TypeError)
[11ty]
[11ty] Original error stack trace: TypeError: Cannot read properties of undefined (reading '#text')
[11ty]     at file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/import/src/DataSource/Rss.js:56:76
[11ty]     at Array.map (<anonymous>)
[11ty]     at Rss.getHtmlFromMediaEntry (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/import/src/DataSource/Rss.js:55:6)
[11ty]     at Rss.cleanEntry (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/import/src/DataSource/Rss.js:86:25)
[11ty]     at Rss.getCleanedEntries (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/import/src/DataSource.js:142:31)
[11ty]     at async Rss.getEntries (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/import/src/DataSource.js:198:22)
[11ty]     at async Importer.getEntries (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/import/src/Importer.js:333:21)
[11ty]     at async default.render (file:///E:/Git/fossgaming-pages-data/src/follow-feed.11ty.js:27:21)
[11ty]     at async Template._render (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/eleventy/src/TemplateContent.js:608:19)
[11ty]     at async TemplateMap.populateContentDataInMap (file:///E:/Git/fossgaming-pages-data/node_modules/@11ty/eleventy/src/TemplateMap.js:545:7)
```

This PR sets the image alt text to an empty string if there isn't a description.